### PR TITLE
got rid of shared memory exception, just return null/None in ScriptSharedMemory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+export PATH=$JAVA_HOME/bin:$PATH 
+
+./gradlew --info clean build

--- a/src/burp_hotpatch/scripts/ScriptSharedMemory.java
+++ b/src/burp_hotpatch/scripts/ScriptSharedMemory.java
@@ -31,10 +31,7 @@ public class ScriptSharedMemory {
         integers.put(name,num);
     }
 
-    public int getInt( String name ) throws ScriptSharedMemoryException {
-        if ( integers.get(name) == null ) {
-            throw new ScriptSharedMemoryException(String.format("Key %s does not exist", name));
-        }
+    public Integer getInt( String name ) {
         return integers.get(name);
     }
 
@@ -42,10 +39,7 @@ public class ScriptSharedMemory {
         strings.put(name,str);
     }
 
-    public String getString( String name ) throws ScriptSharedMemoryException {
-        if ( strings.get(name) == null ) {
-            throw new ScriptSharedMemoryException(String.format("Key %s does not exist", name));
-        }
+    public String getString( String name ) {
         return strings.get(name);
     }
 
@@ -53,10 +47,7 @@ public class ScriptSharedMemory {
         objects.put(name,obj);
     }
 
-    public Object getObject( String name ) throws ScriptSharedMemoryException {
-        if ( objects.get(name) == null ) {
-            throw new ScriptSharedMemoryException(String.format("Key %s does not exist", name));
-        }
+    public Object getObject( String name ) {
         return objects.get(name);
     }
 

--- a/src/burp_hotpatch/scripts/ScriptSharedMemoryException.java
+++ b/src/burp_hotpatch/scripts/ScriptSharedMemoryException.java
@@ -1,6 +1,0 @@
-package burp_hotpatch.scripts;
-public class ScriptSharedMemoryException extends Exception {
-    public ScriptSharedMemoryException(String errorMessage) {
-        super(errorMessage);
-    }
-}

--- a/test/SharedMemoryTests.java
+++ b/test/SharedMemoryTests.java
@@ -1,14 +1,14 @@
 import burp_hotpatch.scripts.ScriptSharedMemory;
-import burp_hotpatch.scripts.ScriptSharedMemoryException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SharedMemoryTests {
     @Test
     @DisplayName("Test shared memory read and write string")
-    public void sharedMemoryReadWriteString() throws ScriptSharedMemoryException {
+    public void sharedMemoryReadWriteString() {
         String testVal = "1234";
         ScriptSharedMemory sharedMemory = ScriptSharedMemory.getInstance();
         sharedMemory.setString("test",testVal);
@@ -17,10 +17,18 @@ public class SharedMemoryTests {
 
     @Test
     @DisplayName("Test shared memory read and write integer")
-    public void sharedMemoryReadInteger() throws ScriptSharedMemoryException {
+    public void sharedMemoryReadInteger() {
         int testVal = 1234;
         ScriptSharedMemory sharedMemory = ScriptSharedMemory.getInstance();
         sharedMemory.setInt("test",testVal);
         assertEquals(testVal, sharedMemory.getInt("test"));
+    }
+
+
+    @Test
+    @DisplayName("Test shared memory read a missing key becomes null")
+    public void sharedMemoryReadIntegerNull() {
+        ScriptSharedMemory sharedMemory = ScriptSharedMemory.getInstance();
+        assertNull(sharedMemory.getInt("asdf"));
     }
 }


### PR DESCRIPTION
got rid of the exception throwing behavior on ScriptSharedMemory

just returns null (which is mapped to None in python via some kind of graal  voodoo)